### PR TITLE
manifest version 2

### DIFF
--- a/build.js
+++ b/build.js
@@ -168,8 +168,9 @@ core.register({
     name: 'prologue',
     type: '@core/prologue'
   }, {
-    name: 'unencrypted',
-    type: 'bool'
+    name: 'linked',
+    array: true,
+    type: 'fixed32'
   }]
 })
 

--- a/spec/hyperschema/index.js
+++ b/spec/hyperschema/index.js
@@ -245,6 +245,8 @@ const encoding8 = {
 
 // @core/manifest.signers
 const encoding9_4 = c.array(encoding7)
+// @core/manifest.linked
+const encoding9_6 = c.array(c.fixed32)
 
 // @core/manifest
 const encoding9 = {
@@ -256,12 +258,13 @@ const encoding9 = {
     encoding9_4.preencode(state, m.signers)
 
     if (m.prologue) encoding8.preencode(state, m.prologue)
+    if (m.linked) encoding9_6.preencode(state, m.linked)
   },
   encode (state, m) {
     const flags =
       (m.allowPatch ? 1 : 0) |
       (m.prologue ? 2 : 0) |
-      (m.unencrypted ? 4 : 0)
+      (m.linked ? 4 : 0)
 
     c.uint.encode(state, m.version)
     c.uint.encode(state, flags)
@@ -270,6 +273,7 @@ const encoding9 = {
     encoding9_4.encode(state, m.signers)
 
     if (m.prologue) encoding8.encode(state, m.prologue)
+    if (m.linked) encoding9_6.encode(state, m.linked)
   },
   decode (state) {
     const r0 = c.uint.decode(state)
@@ -282,7 +286,7 @@ const encoding9 = {
       allowPatch: (flags & 1) !== 0,
       signers: encoding9_4.decode(state),
       prologue: (flags & 2) !== 0 ? encoding8.decode(state) : null,
-      unencrypted: (flags & 4) !== 0
+      linked: (flags & 4) !== 0 ? encoding9_6.decode(state) : null
     }
   }
 }

--- a/spec/hyperschema/schema.json
+++ b/spec/hyperschema/schema.json
@@ -237,8 +237,9 @@
           "version": 1
         },
         {
-          "name": "unencrypted",
-          "type": "bool",
+          "name": "linked",
+          "array": true,
+          "type": "fixed32",
           "version": 1
         }
       ]


### PR DESCRIPTION
- manifest now includes a `linked` field to signal associated cores as a fixed32 array
- `unencrypted` flag is dropped