### PR TITLE
(on-hold) Add suspend/resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ const Storage = require('hypercore-storage')
 
 Make a new storage engine.
 
-#### `core = await store.create({ key, discoveyKey, manifest?, keyPair?, encryptionKey?, userData? })`
+#### `core = await store.createCore({ key, discoveyKey, manifest?, keyPair?, encryptionKey?, userData? })`
 
 Create a new core, returns a storage instance for that core.
 
-#### `core = await store.continue(discoveryKey)`
+#### `core = await store.resumeCore(discoveryKey)`
 
-Continue a previously made core. If it doesn't exist it returns `null`.
+Resume a previously made core. If it doesn't exist it returns `null`.
 
 #### `atom = store.createAtom()`
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Make a new storage engine.
 
 Create a new core, returns a storage instance for that core.
 
-#### `core = await store.resume(discoveryKey)`
+#### `core = await store.continue(discoveryKey)`
 
-Resume a previously make core. If it doesn't exist it returns `null`.
+Continue a previously made core. If it doesn't exist it returns `null`.
 
 #### `atom = store.createAtom()`
 

--- a/index.js
+++ b/index.js
@@ -419,8 +419,6 @@ class HypercoreStorage {
 }
 
 class CorestoreStorage {
-  _suspended = false
-
   constructor(db, opts = {}) {
     const storage = typeof db === 'string' ? db : null
 
@@ -441,6 +439,7 @@ class CorestoreStorage {
     this.flushing = null
     this.version = 0
     this.migrating = null
+    this._suspended = false
   }
 
   get opened() {

--- a/index.js
+++ b/index.js
@@ -857,7 +857,7 @@ class CorestoreStorage {
     return authPromise
   }
 
-  async continue(discoveryKey) {
+  async resumeCore(discoveryKey) {
     if (this.version === 0) await this._migrateStore()
 
     if (!discoveryKey) {
@@ -971,7 +971,7 @@ class CorestoreStorage {
     return new HypercoreStorage(this, this.db.session(), ptr, EMPTY, null)
   }
 
-  async create(data) {
+  async createCore(data) {
     if (this.version === 0) await this._migrateStore()
 
     const view = await this._enter()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore-storage",
-  "version": "1.16.0",
+  "version": "2.0.0",
   "main": "index.js",
   "files": [
     "index.js",

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -250,9 +250,9 @@ test('basic atomized flow with multiple cores', async (t) => {
   const key2 = b4a.from('2'.repeat(64), 'hex')
 
   const cores = await Promise.all([
-    storage.create({ key: key0, discoveryKey: key0 }),
-    storage.create({ key: key1, discoveryKey: key1 }),
-    storage.create({ key: key2, discoveryKey: key2 })
+    storage.createCore({ key: key0, discoveryKey: key0 }),
+    storage.createCore({ key: key1, discoveryKey: key1 }),
+    storage.createCore({ key: key2, discoveryKey: key2 })
   ])
   const [core0, core1, core2] = cores
   t.teardown(async () => {

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,9 +6,9 @@ test('make storage and core', async function (t) {
   const s = await create(t)
 
   t.is(await s.has(b4a.alloc(32)), false)
-  t.is(await s.continue(b4a.alloc(32)), null)
+  t.is(await s.resumeCore(b4a.alloc(32)), null)
 
-  const c = await s.create({ key: b4a.alloc(32), discoveryKey: b4a.alloc(32) })
+  const c = await s.createCore({ key: b4a.alloc(32), discoveryKey: b4a.alloc(32) })
 
   t.is(await s.has(b4a.alloc(32)), true)
 
@@ -16,7 +16,7 @@ test('make storage and core', async function (t) {
 
   t.is(await s.has(b4a.alloc(32)), true)
 
-  const r = await s.continue(b4a.alloc(32))
+  const r = await s.resumeCore(b4a.alloc(32))
 
   t.ok(!!r)
 
@@ -29,7 +29,7 @@ test('make many in parallel', async function (t) {
 
   const all = []
   for (let i = 0; i < 50; i++) {
-    const c = s.create({
+    const c = s.createCore({
       key: b4a.alloc(32, i),
       discoveryKey: b4a.alloc(32, i)
     })
@@ -55,11 +55,11 @@ test('first core created is the default core', async function (t) {
   const s = await create(t)
 
   t.is(await s.getDefaultDiscoveryKey(), null)
-  const c = await s.create({ key: b4a.alloc(32), discoveryKey: b4a.alloc(32) })
+  const c = await s.createCore({ key: b4a.alloc(32), discoveryKey: b4a.alloc(32) })
 
   t.alike(await s.getDefaultDiscoveryKey(), b4a.alloc(32))
 
-  const c1 = await s.create({
+  const c1 = await s.createCore({
     key: b4a.alloc(32, 1),
     discoveryKey: b4a.alloc(32, 1)
   })
@@ -75,7 +75,7 @@ test('first core created is the default core', async function (t) {
   const s = await create(t)
 
   t.is(await s.getDefaultDiscoveryKey(), null)
-  const c = await s.create({
+  const c = await s.createCore({
     key: b4a.alloc(32, 1),
     discoveryKey: b4a.alloc(32, 2)
   })
@@ -101,7 +101,7 @@ test('write during close', async function (t) {
   const s = await create(t)
 
   t.is(await s.getDefaultDiscoveryKey(), null)
-  const c = await s.create({
+  const c = await s.createCore({
     key: b4a.alloc(32, 1),
     discoveryKey: b4a.alloc(32, 2)
   })
@@ -123,7 +123,7 @@ test('audit v0 cores', async function (t) {
 
   const all = []
   for (let i = 0; i < 35; i++) {
-    const c = s.create({
+    const c = s.createCore({
       key: b4a.alloc(32, i),
       discoveryKey: b4a.alloc(32, i)
     })

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,7 +6,7 @@ test('make storage and core', async function (t) {
   const s = await create(t)
 
   t.is(await s.has(b4a.alloc(32)), false)
-  t.is(await s.resume(b4a.alloc(32)), null)
+  t.is(await s.continue(b4a.alloc(32)), null)
 
   const c = await s.create({ key: b4a.alloc(32), discoveryKey: b4a.alloc(32) })
 
@@ -16,7 +16,7 @@ test('make storage and core', async function (t) {
 
   t.is(await s.has(b4a.alloc(32)), true)
 
-  const r = await s.resume(b4a.alloc(32))
+  const r = await s.continue(b4a.alloc(32))
 
   t.ok(!!r)
 

--- a/test/core.js
+++ b/test/core.js
@@ -31,9 +31,9 @@ test('read and write hypercore blocks across multiple cores', async (t) => {
   }
 
   const [core0, core1, core2] = await Promise.all([
-    storage.create(keys0),
-    storage.create(keys1),
-    storage.create(keys2)
+    storage.createCore(keys0),
+    storage.createCore(keys1),
+    storage.createCore(keys2)
   ])
 
   await Promise.all([
@@ -676,7 +676,7 @@ test('create named sessions', async (t) => {
 
 test('export hypercore', async (t) => {
   const s = await create(t)
-  const core = await s.create({
+  const core = await s.createCore({
     key: b4a.alloc(32),
     discoveryKey: b4a.alloc(32)
   })
@@ -752,7 +752,7 @@ test('export hypercore', async (t) => {
 
 test('export named sessions', async (t) => {
   const s = await create(t)
-  const core = await s.create({
+  const core = await s.createCore({
     key: b4a.alloc(32),
     discoveryKey: b4a.alloc(32)
   })
@@ -814,7 +814,7 @@ test('export named sessions', async (t) => {
 
 test('compact core', async (t) => {
   const s = await create(t)
-  const core = await s.create({
+  const core = await s.createCore({
     key: b4a.alloc(32),
     discoveryKey: b4a.alloc(32)
   })

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -19,7 +19,7 @@ module.exports = {
 
 async function createCore(t) {
   const s = await create(t)
-  const core = await s.create({
+  const core = await s.createCore({
     key: b4a.alloc(32),
     discoveryKey: b4a.alloc(32)
   })

--- a/test/readonly.js
+++ b/test/readonly.js
@@ -1,6 +1,5 @@
 const test = require('brittle')
 const b4a = require('b4a')
-const { create } = require('./helpers')
 const tmp = require('test-tmp')
 const Storage = require('../')
 
@@ -9,7 +8,7 @@ test('make storage and core', async function (t) {
   const w = new Storage(dir)
 
   t.is(await w.has(b4a.alloc(32)), false)
-  t.is(await w.continue(b4a.alloc(32)), null)
+  t.is(await w.resumeCore(b4a.alloc(32)), null)
 
   await w.db.suspend()
   await w.db.resume()

--- a/test/readonly.js
+++ b/test/readonly.js
@@ -1,0 +1,30 @@
+const test = require('brittle')
+const b4a = require('b4a')
+const { create } = require('./helpers')
+const tmp = require('test-tmp')
+const Storage = require('../')
+
+test('make storage and core', async function (t) {
+  const dir = await tmp(t)
+  const w = new Storage(dir)
+
+  t.is(await w.has(b4a.alloc(32)), false)
+  t.is(await w.continue(b4a.alloc(32)), null)
+
+  await w.db.suspend()
+  await w.db.resume()
+
+  const ro = new Storage(dir, { readOnly: true })
+
+  t.is(w.path, ro.path)
+
+  await ro.suspend()
+  t.ok(ro.db._state._suspending)
+  await ro.resume()
+  t.absent(ro.db._state._suspending)
+
+  await w.close()
+  await ro.close()
+
+  t.pass()
+})

--- a/test/streams.js
+++ b/test/streams.js
@@ -286,9 +286,9 @@ test('discoveryKey stream', async function (t) {
   for (let i = 0; i < 10; i++) {
     const discoveryKey = crypto.randomBytes(32)
     if (i < 5) {
-      await s.create({ key: crypto.randomBytes(32), discoveryKey })
+      await s.createCore({ key: crypto.randomBytes(32), discoveryKey })
     } else {
-      await s.create({
+      await s.createCore({
         key: crypto.randomBytes(32),
         discoveryKey,
         alias: { name: `core-${i}`, namespace }


### PR DESCRIPTION
This came about as there is segmentation fault when suspending an unopened readonly rocksdb. This brings us to the fact that corestore is touching the db directly a lot. Below allows `hypercore-storage` to manage this for us.

* Rename resume to continue <- **chore!: Breaking**
* Suspend and resume support
* Skip flush if readOnly
