### PR TITLE
Add basic test of migration from corestore v6.18.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
       "bare": "bare-fs",
       "default": "fs"
     },
+    "fs/*": {
+      "bare": "bare-fs/*",
+      "default": "fs/*"
+    },
     "path": {
       "bare": "bare-path",
       "default": "path"
@@ -54,6 +58,7 @@
   },
   "devDependencies": {
     "brittle": "^3.7.0",
+    "corestore-6.18.4": "npm:corestore@^6.18.4",
     "lunte": "^1.3.0",
     "prettier": "^3.6.2",
     "prettier-config-holepunch": "^2.0.0",

--- a/test/all.js
+++ b/test/all.js
@@ -13,5 +13,8 @@ async function runTests() {
   await import('./snapshot.js')
   await import('./streams.js')
 
+  // Fixtures
+  await import('./migration.js')
+
   test.resume()
 }

--- a/test/migration.js
+++ b/test/migration.js
@@ -29,10 +29,10 @@ test('migration - basic from corestore@6.18.4', async (t) => {
 
   t.ok(await storage.hasCore(coreDKey), 'finds old core & triggers migration')
   t.is(storage.version, 1, 'version 1')
-  t.absent(await fileExists(primaryKeyFile), 'primary key was gc\'ed')
+  t.absent(await fileExists(primaryKeyFile), "primary key was gc'ed")
 })
 
-async function fileExists (path) {
+async function fileExists(path) {
   try {
     await access(path)
     return true

--- a/test/migration.js
+++ b/test/migration.js
@@ -19,10 +19,12 @@ test('migration - basic from corestore@6.18.4', async (t) => {
     coreDKey = a.discoveryKey // setup for opening later
     t.is(await a.get(0), 'beep')
     t.ok(await fileExists(primaryKeyFile), 'primary key file exists from old version')
+    await store.close()
   }
 
   // New storage
   const storage = new CorestoreStorage(dir)
+  t.teardown(() => storage.close())
   t.is(storage.version, 0, 'version 0')
 
   t.ok(await fileExists(primaryKeyFile), 'primary key file exists')

--- a/test/migration.js
+++ b/test/migration.js
@@ -1,0 +1,42 @@
+const test = require('brittle')
+const path = require('path')
+const { access } = require('fs/promises')
+const Corestore6_18_4 = require('corestore-6.18.4')
+const CorestoreStorage = require('../index.js')
+
+test('migration - basic from corestore@6.18.4', async (t) => {
+  const dir = await t.tmp()
+  let coreKey
+  let coreDKey
+  const primaryKeyFile = path.join(dir, 'primary-key')
+  // Setup old core
+  {
+    const store = new Corestore6_18_4(dir)
+    const a = store.get({ name: 'a', valueEncoding: 'utf8' })
+    await a.ready()
+    await a.append('beep')
+    coreKey = a.key // setup for opening later
+    coreDKey = a.discoveryKey // setup for opening later
+    t.is(await a.get(0), 'beep')
+    t.ok(await fileExists(primaryKeyFile), 'primary key file exists from old version')
+  }
+
+  // New storage
+  const storage = new CorestoreStorage(dir)
+  t.is(storage.version, 0, 'version 0')
+
+  t.ok(await fileExists(primaryKeyFile), 'primary key file exists')
+
+  t.ok(await storage.hasCore(coreDKey), 'finds old core & triggers migration')
+  t.is(storage.version, 1, 'version 1')
+  t.absent(await fileExists(primaryKeyFile), 'primary key was gc\'ed')
+})
+
+async function fileExists (path) {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Currently a minimal example of testing migrations via using aliases for older versions of modules.