### PR TITLE
Bump minimum version for `hyperschema`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "device-file": "^2.1.2",
     "flat-tree": "^1.12.1",
     "hypercore-crypto": "^3.4.2",
-    "hyperschema": "^1.7.0",
+    "hyperschema": "^1.21.0",
     "index-encoder": "^3.3.2",
     "resolve-reject-promise": "^1.0.0",
     "rocksdb-native": "^3.11.0",


### PR DESCRIPTION
Without the minimum version, `hypercore-storage` installations can upgrade `hypercore-storage` but not update `hyperschema`. This leads to the `compact-encoding` used for the schema to be `2.*` which doesn't support the generated schema's `optionalBuffer`.